### PR TITLE
Conformance to AFNetworking 4.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "AFNetworking"]
-	path = AFNetworking
-	url = https://github.com/AFNetworking/AFNetworking.git

--- a/CargoBay/CargoBay.m
+++ b/CargoBay/CargoBay.m
@@ -914,8 +914,6 @@ NSDictionary * CBPurchaseInfoFromTransactionReceipt(NSData *transactionReceiptDa
                     return credential;
                 }
             }
-            
-            result = NSURLSessionAuthChallengeCancelAuthenticationChallenge;
         } else {
             result = NSURLSessionAuthChallengePerformDefaultHandling;
         }


### PR DESCRIPTION
### Description
We need to use the new version of `AFNetworking`, `4.0.0`, to remove dependencies from the deprecated `UIWebView`. This new version uses a slightly different method to handle authentication challenges, so the code in `CargoBay` needs to be updated to conform to the new syntax.